### PR TITLE
すでに投稿されているファイルをすべてダウンロードされるようにした close #53 #45 #38

### DIFF
--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -1,7 +1,28 @@
 import fg from 'fast-glob';
+import fs from 'fs';
+import matter from 'gray-matter';
+import { QiitaPost } from '~/types/qiita';
 
 export function loadArticleFiles(rootDir: string): string[] {
   return fg.sync([rootDir, '**', '*.md'].join('/'), { dot: true });
 }
 
 export const defaultProjectName = 'articles';
+
+export function writeFrontmatterMarkdownFileWithQiitaPost(
+  filePath: string,
+  qiitaPost: QiitaPost
+) {
+  const saveMarkdownFile = matter.stringify(qiitaPost.body, {
+    id: qiitaPost.id,
+    title: qiitaPost.title,
+    created_at: qiitaPost.created_at,
+    updated_at: qiitaPost.updated_at,
+    tags: JSON.stringify(qiitaPost.tags),
+    private: qiitaPost.private,
+    url: qiitaPost.url,
+    likes_count: qiitaPost.likes_count,
+  });
+  // write frontMatter
+  fs.writeFileSync(filePath, saveMarkdownFile);
+}

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -13,9 +13,12 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
   filePath: string,
   qiitaPost: QiitaPost
 ) {
+  const group_url_name = qiitaPost.group ? qiitaPost.group.url_name : null;
   const saveMarkdownFile = matter.stringify(qiitaPost.body, {
     id: qiitaPost.id,
     title: qiitaPost.title,
+    coediting: qiitaPost.coediting,
+    group_url_name: group_url_name,
     created_at: qiitaPost.created_at,
     updated_at: qiitaPost.updated_at,
     tags: qiitaPost.tags.map((tagObj) => {

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -18,7 +18,9 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
     title: qiitaPost.title,
     created_at: qiitaPost.created_at,
     updated_at: qiitaPost.updated_at,
-    tags: JSON.stringify(qiitaPost.tags),
+    tags: qiitaPost.tags.map((tagObj) => {
+      return { name: tagObj.name };
+    }),
     private: qiitaPost.private,
     url: qiitaPost.url,
     likes_count: qiitaPost.likes_count,

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -79,7 +79,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
     const saveMarkdownFile = matter.stringify(body, {
       id: '',
       title: answers.article_title,
-      tags: [{ name: 'qiita-cli', versions: [] }],
+      tags: [{ name: 'qiita-cli' }],
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,6 +4,7 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
+import matter from 'gray-matter';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function newArticle(options: ExtraInputOptions): Promise<number> {
@@ -53,12 +54,6 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
     } else {
       fs.mkdirSync(articleDir);
     }
-    const frontMatter = `---
-id: 
-title: ${answers.article_title}
-tags: [{"name":"qiita-cli","versions":[]}]
----  
-      `;
     const body = `
 ここから本文を書く
 # ${emoji.get('hatched_chick')} qiita cliによる自動生成です.
@@ -81,9 +76,13 @@ tags: [{"name":"C++","versions":[]},{"name":"AtCoder","versions":[]}]
 qiita cliはローカル上で新規記事/修正記事かどうかはファイル名により判断します.
 \`not_uploaded.md\`というファイル名はそのままに ${emoji.get('bow')}
 `;
-    // sync writ for frontMatter
-    fs.writeFileSync(articlePath, frontMatter);
-    fs.appendFileSync(articlePath, body);
+    const saveMarkdownFile = matter.stringify(body, {
+      id: '',
+      title: answers.article_title,
+      tags: [{ name: 'qiita-cli', versions: [] }],
+    });
+    // write frontMatter
+    fs.writeFileSync(articlePath, saveMarkdownFile);
 
     // 処理完了メッセージ
     console.log(

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -80,6 +80,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
       id: '',
       title: answers.article_title,
       tags: [{ name: 'qiita-cli' }],
+      private: true,
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -4,9 +4,12 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
-import { QiitaPostResponse, Tag } from '~/types/qiita';
+import { QiitaPost, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  writeFrontmatterMarkdownFileWithQiitaPost,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -53,7 +56,7 @@ export async function patchArticle(
     // 記事id
     const articleId: string = uploadMatterMarkdown.data.id;
 
-    const res = await axios.patch<QiitaPostResponse>(
+    const res = await axios.patch<QiitaPost>(
       'https://qiita.com/api/v2/items/' + String(articleId),
       {
         body: articleContentsBody,
@@ -82,6 +85,7 @@ export async function patchArticle(
           emoji.get('sparkles') +
           '\n'
       );
+      writeFrontmatterMarkdownFileWithQiitaPost(postFilePath, res.data);
     } else {
       // 記事投稿失敗
       console.log(

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -60,9 +60,9 @@ export async function patchArticle(
       'https://qiita.com/api/v2/items/' + String(articleId),
       {
         body: articleContentsBody,
-        coediting: false,
-        group_url_name: 'dev',
-        private: false,
+        coediting: uploadMatterMarkdown.data.coediting,
+        group_url_name: uploadMatterMarkdown.data.group_url_name,
+        private: uploadMatterMarkdown.data.private || false,
         tags: tags,
         title: title,
       },

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -55,9 +55,9 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
       'https://qiita.com/api/v2/items/',
       {
         body: articleContentsBody,
-        coediting: false,
-        group_url_name: 'dev',
-        private: false,
+        coediting: uploadMatterMarkdown.data.coediting,
+        group_url_name: uploadMatterMarkdown.data.group_url_name,
+        private: uploadMatterMarkdown.data.private || false,
         tags: tags,
         title: title,
         tweet: false,

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -3,9 +3,12 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
-import { QiitaPostResponse, Tag } from '~/types/qiita';
+import { QiitaPost, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  writeFrontmatterMarkdownFileWithQiitaPost,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -48,7 +51,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     // 記事本文
     const articleContentsBody = uploadMatterMarkdown.content;
 
-    const res = await axios.post<QiitaPostResponse>(
+    const res = await axios.post<QiitaPost>(
       'https://qiita.com/api/v2/items/',
       {
         body: articleContentsBody,
@@ -78,17 +81,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
           emoji.get('sparkles') +
           '\n'
       );
-      const renewalPost = matter.stringify(postData.body, {
-        id: postData.id,
-        title: postData.title,
-        created_at: postData.created_at,
-        updated_at: postData.updated_at,
-        tags: JSON.stringify(postData.tags),
-        private: postData.private,
-        url: postData.url,
-        likes_count: postData.likes_count,
-      });
-      fs.writeFileSync(postFilePath, renewalPost);
+      writeFrontmatterMarkdownFileWithQiitaPost(postFilePath, postData);
     } else {
       // 記事投稿失敗
       console.log(

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -2,7 +2,6 @@ import axios, { AxiosResponse } from 'axios';
 import emoji from 'node-emoji';
 import fs from 'fs';
 import path from 'path';
-import matter from 'gray-matter';
 // import 形式だとファイルが存在しない状態でエラーが起こるので、import形式を一旦取りやめる
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost, User } from '@/types/qiita';

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,6 +7,7 @@ import matter from 'gray-matter';
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost, User } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
+import { writeFrontmatterMarkdownFileWithQiitaPost } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 const itemsPerPage = 100;
@@ -36,18 +37,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
         const dir: string = path.join(options.project, post.title);
         const filePath: string = path.join(dir, post.id + '.md');
         fs.mkdirSync(dir, { recursive: true });
-        const saveMarkdownFile = matter.stringify(post.body, {
-          id: post.id,
-          title: post.title,
-          created_at: post.created_at,
-          updated_at: post.updated_at,
-          tags: JSON.stringify(post.tags),
-          private: post.private,
-          url: post.url,
-          likes_count: post.likes_count,
-        });
-        // write frontMatter
-        fs.writeFileSync(filePath, saveMarkdownFile);
+        writeFrontmatterMarkdownFileWithQiitaPost(filePath, post);
       }
       console.log('------------------------------------------');
       if (itemCount <= page * itemsPerPage) {

--- a/types/qiita.d.ts
+++ b/types/qiita.d.ts
@@ -4,7 +4,7 @@ export interface QiitaPost {
   coediting: boolean;
   comments_count: number;
   created_at: string;
-  group: null;
+  group: null | Group;
   id: string;
   likes_count: number;
   private: boolean;
@@ -14,44 +14,7 @@ export interface QiitaPost {
   updated_at: string;
   url: string;
   user: User;
-  page_views_count: null;
-}
-
-export interface QiitaPostResponse {
-  rendered_body: string;
-  body: string;
-  coediting: boolean;
-  comments_count: number;
-  created_at: string;
-  group: null | string;
-  id: string;
-  likes_count: number;
-  private: boolean;
-  reactions_count: number;
-  tags: [];
-  title: string;
-  updated_at: string;
-  url: string;
-  user: {
-    description: string;
-    facebook_id: string;
-    followees_count: number;
-    followers_count: number;
-    github_login_name: string;
-    id: string;
-    items_count: number;
-    linkedin_id: string;
-    location: string;
-    name: string;
-    organization: string;
-    permanent_id: number;
-    profile_image_url: string;
-    team_only: boolean;
-    twitter_screen_name: null | string;
-    website_url: string;
-  };
-  page_views_count: null | string;
-  team_membership: null | string;
+  page_views_count: number;
 }
 
 export interface Tag {
@@ -60,20 +23,29 @@ export interface Tag {
 }
 
 export interface User {
-  description: null | string;
-  facebook_id: null | string;
+  description: string;
+  facebook_id: string;
   followees_count: number;
   followers_count: number;
-  github_login_name: null | string;
+  github_login_name: string;
   id: string;
   items_count: number;
-  linkedin_id: null | string;
-  location: null | string;
+  linkedin_id: string;
+  location: string;
   name: string;
-  organization: string | null;
+  organization: string;
   permanent_id: number;
   profile_image_url: string;
   team_only: boolean;
-  twitter_screen_name: null | string;
-  website_url: null | string;
+  twitter_screen_name: string;
+  website_url: string;
+}
+
+export interface Group {
+  created_at: string,
+  description: string,
+  name: string,
+  private: boolean,
+  updated_at: string,
+  url_name: string,
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/53
https://github.com/antyuntyuntyun/qiita-cli/issues/45
https://github.com/antyuntyuntyun/qiita-cli/issues/38

## 対応概要

- 現状（As is）
  - 記事のダウンロードは全件ではなく100件ぐらいまでと思われる

- 理想（To be）
  - 可能な限り(最大10000件) の記事をダウンロードできるようにしたい

- 問題（Problem）
  - 本件の実装にあたり細かい部分での使用感も変更した
    - 投稿する時に付与する必要がある情報も全て記事のfront-matterに書き込まれるように修正した
    - front-matterの値を参照して記事を投稿するように変更した
  - Qiita APIにて使われている型(interface)も一緒に整理&共通化した
  - 結果的にいくつかのissueも一緒に対応することになってしまった

- 解決・やったこと（Action）
  - 可能な限り(最大10000件)の記事をダウンロードできるようにした
  - Qiita API関係の型(interface) の共通化と整理を行った
  - front-matterへの書き込みは gray-matter を使用したものに統一した
    - これに関連して tags の部分をJSONではなくyamlの形で保存されるようにした
    - tagsの中にversionsの項目があると投稿時にエラーとなってしまうので、これは除去した

## 備考
https://github.com/antyuntyuntyun/qiita-cli/pull/50
https://github.com/antyuntyuntyun/qiita-cli/pull/51
こちら上から順番に上記のPRが適用された後にこちらのPRを見ていただければと思います。
本件の実装にあたり付随していたissueも巻き込んだ形で対応してしまっております。
動作の確認をして問題がないことは確認していますが、変更を希望するところなどありましたらご指摘ください。
よろしくお願いします