### PR TITLE
コマンドオプション --all を指定したら、ディレクトリ以下にある記事を投稿できるようにした close #52

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ program
     '-f, --file <uploadFilePath>',
     `投稿したい記事のファイルを指定してください`
   )
+  .option('--all', `プロジェクト以下に存在する全ての記事を投稿する`)
   .action(async (options: ExtraInputOptions) => {
     await postArticle(options);
   });

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -6,4 +6,5 @@ export interface ExtraInputOptions {
   token: string;
   project: string;
   file: string;
+  all: boolean;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/52

## 対応概要

- 現状（As is）
  - 1記事づつしか投稿することができない

- 理想（To be）
  - 更新がある、または新しい記事全てを投稿できる機能がある

- 問題（Problem）
  - 全ての記事を更新できるようにしたが、編集されていないものまで更新できてしまう
  - そのためQiita APIを実行する回数が多い

- 解決・やったこと（Action）
  - allコマンドオプションが指定されると全ての記事を投稿または更新できるようにした

## 備考
https://github.com/antyuntyuntyun/qiita-cli/pull/50
https://github.com/antyuntyuntyun/qiita-cli/pull/51
https://github.com/antyuntyuntyun/qiita-cli/pull/54
https://github.com/antyuntyuntyun/qiita-cli/pull/55
こちら上から順番に上記のPRが適用された後にこちらのPRを見ていただければと思いま