### PR TITLE
記事のハッシュ値より更新が必要な記事のみを投稿するようにした close #56

### DIFF
--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -28,7 +28,7 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
     private: qiitaPost.private,
     url: qiitaPost.url,
     likes_count: qiitaPost.likes_count,
-    hash: createHash('sha256').update(qiitaPost.body).digest('hex')
+    hash: createHash('sha256').update(qiitaPost.body).digest('hex'),
   });
   // write frontMatter
   fs.writeFileSync(filePath, saveMarkdownFile);

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -1,6 +1,7 @@
 import fg from 'fast-glob';
 import fs from 'fs';
 import matter from 'gray-matter';
+import { createHash } from 'crypto';
 import { QiitaPost } from '~/types/qiita';
 
 export function loadArticleFiles(rootDir: string): string[] {
@@ -27,6 +28,7 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
     private: qiitaPost.private,
     url: qiitaPost.url,
     likes_count: qiitaPost.likes_count,
+    hash: createHash('sha256').update(qiitaPost.body).digest('hex')
   });
   // write frontMatter
   fs.writeFileSync(filePath, saveMarkdownFile);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
 import matter from 'gray-matter';
+import { createHash } from 'crypto';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function newArticle(options: ExtraInputOptions): Promise<number> {
@@ -81,6 +82,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
       title: answers.article_title,
       tags: [{ name: 'qiita-cli' }],
       private: true,
+      hash: createHash('sha256').update(body).digest('hex')
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -82,7 +82,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
       title: answers.article_title,
       tags: [{ name: 'qiita-cli' }],
       private: true,
-      hash: createHash('sha256').update(body).digest('hex')
+      hash: createHash('sha256').update(body).digest('hex'),
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -3,6 +3,7 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
+import { createHash } from 'crypto';
 import { QiitaPost, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import {
@@ -68,6 +69,12 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
       if (uploadMatterMarkdown.data.id) {
         // 記事id
         const articleId: string = uploadMatterMarkdown.data.id;
+        const beforeHash = uploadMatterMarkdown.data.hash;
+        const currentHash = createHash('sha256')
+          .update(articleContentsBody)
+          .digest('hex');
+        // ハッシュ値が同じ=変更がないということなのでその場合は更新しないで次に行く
+        if (beforeHash === currentHash) continue;
 
         const res = await axios.patch<QiitaPost>(
           'https://qiita.com/api/v2/items/' + String(articleId),


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/56

## 対応概要

- 現状（As is）
  - 記事を編集していなくても更新してしまう
  - 記事の数が多いとQiita APIを叩きすぎてしまう

- 理想（To be）
  - 編集を行なった記事のみを投稿する

- 問題（Problem）
  - 記事のfront-matterに記事のハッシュ値を記録しているため、変更この部分を編集したら更新扱いとなってしまう
  - front-matterに記事のハッシュ値は初見では何かわからない
  - ハッシュ値の計算は `SHA256` を用いた。(他の方式の方がいい場合はご相談お願いします)

- 解決・やったこと（Action）
  - front-matterにQiitaの記事の本文のhash値を`hash` をキーにして記録するようにした
  - 投稿時にハッシュ値を比較して更新の有無を判別、記事が更新されていなければ投稿しないようにした

## 備考
https://github.com/antyuntyuntyun/qiita-cli/pull/50
https://github.com/antyuntyuntyun/qiita-cli/pull/51
https://github.com/antyuntyuntyun/qiita-cli/pull/54
https://github.com/antyuntyuntyun/qiita-cli/pull/55
https://github.com/antyuntyuntyun/qiita-cli/pull/57
こちら上から順番に上記のPRが適用された後にこちらのPRを見ていただければと思います。