### PR TITLE
投稿時にツイートオプションをつけて投稿することができるようにした

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ program
     `投稿したい記事のファイルを指定してください`
   )
   .option('--all', `プロジェクト以下に存在する全ての記事を投稿する`)
+  .option('--tweet', `新規投稿時にtwitterにも一緒に投稿する`)
   .action(async (options: ExtraInputOptions) => {
     await postArticle(options);
   });

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -121,7 +121,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
             private: uploadMatterMarkdown.data.private || false,
             tags: tags,
             title: title,
-            tweet: false,
+            tweet: options.tweet,
           },
           {
             headers: {

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -7,4 +7,5 @@ export interface ExtraInputOptions {
   project: string;
   file: string;
   all: boolean;
+  tweet: boolean;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/4

## 対応概要

- 現状（As is）
  - tweetオプションをつけて投稿することができない

- 理想（To be）
  - `--tweet` オプションをつければ投稿と同時にtweetされること

- 問題（Problem）
  - 限定公開( `private: true` )の場合はtweetオプションをつけてもTwitterに投稿されない(Qiita APIの仕様)

- 解決・やったこと（Action）
  - `post:article` の際に `--tweet` オプションを指定したら、tweetオプションをつけてQiitaに投稿してくれるようにした

## 備考
https://github.com/antyuntyuntyun/qiita-cli/pull/50
https://github.com/antyuntyuntyun/qiita-cli/pull/51
https://github.com/antyuntyuntyun/qiita-cli/pull/54
https://github.com/antyuntyuntyun/qiita-cli/pull/55
https://github.com/antyuntyuntyun/qiita-cli/pull/57
https://github.com/antyuntyuntyun/qiita-cli/pull/58
こちら上から順番に上記のPRが適用された後にこちらのPRを見ていただければと思います。