### PR TITLE
new:article コマンド実行時の入力を簡素化するsimplifyのオプションを追加した

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,8 @@ qiita --help, -h              ヘルプ
 
 Remark:
 コマンドは全て作業フォルダのルートでの実行を想定したものになっています.
-記事の取得・投稿は作業フォルダはコマンド実行場所の作業フォルダ内のarticlesフォルダを基準に実行されます.
-(articlesフォルダはqiita init や qiit pull コマンドで生成されます)
+記事の取得・投稿は作業フォルダはコマンド実行場所の作業フォルダ内の${defaultProjectName}フォルダを基準に実行されます.
+(${defaultProjectName}フォルダはqiita init や qiit pull コマンドで生成されます)
 `;
 
 /**
@@ -74,6 +74,7 @@ program
     `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
     defaultProjectName
   )
+  .option('-s, --simplify', `入力事項が省略されて新しい記事が作成されます`)
   .action(async (options: ExtraInputOptions) => {
     await newArticle(options);
   });

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -10,17 +10,21 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
   try {
     console.log('Qiita 記事新規作成\n');
 
-    // ユーザ入出力形式指定用変数
-    const inputArticleTitleQuestions: QuestionCollection = [
-      {
-        type: 'input',
-        message: '記事タイトル: ',
-        name: 'article_title',
-      },
-    ];
-    const answers: Answers | { article_title: string } = await prompt(
-      inputArticleTitleQuestions
-    );
+    let articleTitle = '新しい記事のタイトル';
+    if (!options.simplify) {
+      // ユーザ入出力形式指定用変数
+      const inputArticleTitleQuestions: QuestionCollection = [
+        {
+          type: 'input',
+          message: '記事タイトル: ',
+          name: 'article_title',
+        },
+      ];
+      const answers: Answers | { article_title: string } = await prompt(
+        inputArticleTitleQuestions
+      );
+      articleTitle = answers.article_title;
+    }
 
     // 作業ディレクトリに記事用フォルダを作成
     const articleBaseDir = options.project;
@@ -29,7 +33,7 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
     }
 
     // ユーザ入力を元に記事フォルダ/ファイル作成
-    const articleDir = path.join(articleBaseDir, answers.article_title);
+    const articleDir = path.join(articleBaseDir, articleTitle);
     const articlePath = path.join(articleDir, 'not_uploaded.md');
     if (fs.existsSync(articleDir)) {
       // ユーザ入出力形式指定
@@ -78,7 +82,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
     const article = new Article(articlePath);
     await article.writeFileFromQiitaPost({
       id: '',
-      title: answers.article_title,
+      title: articleTitle,
       tags: [{ name: 'qiita-cli' }],
       private: true,
       body: body,

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -8,4 +8,5 @@ export interface ExtraInputOptions {
   file: string;
   all: boolean;
   tweet: boolean;
+  simplify: boolean;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/67

## 対応概要

- 現状（As is）
  - `new:article` コマンドを実行したときに記事のタイトルなどの入力を求められる

- 理想（To be）
  - とりあえず、フォーマットにのっとった記事のテンプレートを作ってくれるようになる

- 問題（Problem）
  -

- 解決・やったこと（Action）
  - `-s, --simplify` オプションを追加して各種入力も省略できるようにした

## 備考
