### PR TITLE
新しく作成される記事のファイル名に乱数を用いたファイル名にしてダブりが発生したり記事作成処理が途中でストップしないようにした。また昔の制約…

### DIFF
--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -18,15 +18,10 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'aricleディレクトリのある作業ディレクトリでコマンド実行している前提での処理です.'
     );
-    console.log(
-      'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
-    );
     const uploadFiles: Set<string> = await buildWillUploadFilePathSet(options);
     if (uploadFiles.size <= 0) {
       console.log(
-        '\n' +
-          emoji.get('disappointed') +
-          ' There are no "not_uploaded.md" files\n'
+        '\n' + emoji.get('disappointed') + ' ファイルが見つかりませんでした\n'
       );
       console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
       return 1;


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/69

## 対応概要

- 現状（As is）
  - `not_uploaded.md` というファイルが固定で作成されてしまう

- 理想（To be）
  - 競合しないファイル名で自動的に作成される

- 問題（Problem）
  -

- 解決・やったこと（Action）
  - QiitaのIDっぽい乱数を用いてファイル名を自動的に生成するようにした
  -  `not_uploaded.md` というファイルを使わなければいけないようなことが書かれている部分を削除した

## 備考