### PR TITLE
 pullしてきたときのファイル名の法則に上書きしてくれる設定を作った

### DIFF
--- a/src/commons/articles.ts
+++ b/src/commons/articles.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import fg from 'fast-glob';
+import path from 'path';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { createHash } from 'crypto';
 import { QiitaPost } from '~/types/qiita';
@@ -100,5 +101,12 @@ export class Article {
     const saveMarkdownFile = matter.stringify(body, matterProperty);
     // write frontMatter
     return fs.promises.writeFile(this.filePath, saveMarkdownFile);
+  }
+
+  renameFile(newFilePath: string): Promise<void> {
+    fs.mkdirSync(path.dirname(newFilePath), { recursive: true });
+    const promise = fs.promises.rename(this.filePath, newFilePath);
+    this.filePath = newFilePath;
+    return promise;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ program
     '-f, --file <uploadFilePath>',
     `投稿したい記事のファイルを指定してください`
   )
+  .option('-o, --overwrite', `新規投稿の場合、 記事のファイル名を "投稿したid名.md" のファイル名に上書きする`)
   .option('--all', `プロジェクト以下に存在する全ての記事を投稿する`)
   .option('--tweet', `新規投稿時にtwitterにも一緒に投稿する`)
   .action(async (options: ExtraInputOptions) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,10 @@ program
     '-f, --file <uploadFilePath>',
     `投稿したい記事のファイルを指定してください`
   )
-  .option('-o, --overwrite', `新規投稿の場合、 記事のファイル名を "投稿したid名.md" のファイル名に上書きする`)
+  .option(
+    '-o, --overwrite',
+    `新規投稿の場合、 記事のファイル名を "投稿したid名.md" のファイル名に上書きする`
+  )
   .option('--all', `プロジェクト以下に存在する全ての記事を投稿する`)
   .option('--tweet', `新規投稿時にtwitterにも一緒に投稿する`)
   .action(async (options: ExtraInputOptions) => {

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -27,17 +27,11 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
       articleTitle = answers.article_title;
     }
 
-    // 作業ディレクトリに記事用フォルダを作成
     const articleBaseDir = options.project;
-    if (!fs.existsSync(articleBaseDir)) {
-      fs.mkdirSync(articleBaseDir);
-    }
-
     // Qiitaのidっぽいランダムな文字列を生成
     const newArticleFileName = randomBytes(10).toString('hex');
-    // ユーザ入力を元に記事フォルダ/ファイル作成
-    const articleDir = path.join(articleBaseDir, articleTitle);
-    const articlePath = path.join(articleDir, `${newArticleFileName}.md`);
+    // 記事のタイトルを基にフォルダ/ファイル作成
+    const articlePath = path.join(articleBaseDir, articleTitle, `${newArticleFileName}.md`);
     if (fs.existsSync(articlePath)) {
       console.log(
         '\n' +
@@ -46,9 +40,8 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
       );
       return 0;
     }
-    if (!fs.existsSync(articleDir)) {
-      fs.mkdirSync(articleDir);
-    }
+    // 作業フォルダに記事用フォルダを作成
+    fs.mkdirSync(path.dirname(articlePath), { recursive: true });
     const body = `
 ここから本文を書く
 # ${emoji.get('hatched_chick')} qiita cliによる自動生成です.

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -1,4 +1,5 @@
 import emoji from 'node-emoji';
+import path from 'path';
 import { prompt, QuestionCollection } from 'inquirer';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { ExtraInputOptions } from '~/types/command';
@@ -50,6 +51,14 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
               '\n'
           );
           writeFilePromises.push(article.writeFileFromQiitaPost(res.data));
+          if (options.overwrite) {
+            const articlePath = path.join(
+              options.project,
+              res.data.title,
+              `${res.data.id}.md`
+            );
+            writeFilePromises.push(article.renameFile(articlePath));
+          }
         } else {
           // 記事投稿失敗
           console.log(

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -9,4 +9,5 @@ export interface ExtraInputOptions {
   all: boolean;
   tweet: boolean;
   simplify: boolean;
+  overwrite: boolean;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/71

## 対応概要

- 現状（As is）
  - 新規投稿をしてもファイル名が変わらないままである

- 理想（To be）
  - pullしてきたときのファイル名の法則に上書きしてくれる設定がある

- 問題（Problem）
  -

- 解決・やったこと（Action）
  - `-o, --overwrite` オプションをつけて投稿するとファイルをリネームしてくれるようにしました

## 備考
