### PR TITLE
LINCENSEがapache-2.0に指定しているのだからpackage.jsonもそのように設定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --config .prettierrc --write \"src/**/*.{ts,js}\""
   },
   "author": "antyuntyun",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",


### PR DESCRIPTION
## 対応issue

Resolve

## 対応概要

- 現状（As is）
  - ISCと表記されている

- 理想（To be）
  - LICENSEの指定がApache-2.0なのでそう記述すべき

- 問題（Problem）
  -

- 解決・やったこと（Action）
  - Apache-2.0に記述を変更した

## 備考
