### PR TITLE
【bugfix】pull:article 時にすでに設定されているaccessTokenを参照していない状態だったため修正

### DIFF
--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -30,7 +30,7 @@ export async function pullArticle(
     const currentIdArticles: {
       [articleId: string]: Article;
     } = loadCurrentIdToArticle(options.project);
-    const authenticatedUser = await loadAuthenticatedUser(options.token);
+    const authenticatedUser = await loadAuthenticatedUser(qiitaSetting.token);
     // 公開している記事数
     const itemCount = authenticatedUser.data.items_count;
     for (let page = 1; page <= maxPageNumber; ++page) {


### PR DESCRIPTION
## 対応issue

Resolve

## 対応概要

- 現状（As is）
  - pull:article 時にすでに設定されているaccessTokenを参照しておらず、`-t` オプションの情報を参照してしまっていた

- 理想（To be）
  - pull:article 時にすでに設定されていればその値を参照する

- 問題（Problem）
  -

- 解決・やったこと（Action）
  - バグの修正

## 備考
